### PR TITLE
Read basic-auth data from secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.9.0
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -163,6 +163,10 @@ type StatusCakeConfig struct {
 	// +optional
 	BasicAuthUser string `json:"basicAuthUser,omitempty"`
 
+	// Basic Auth String
+	// +optional
+	BasicAuthSecret string `json:"basicAuthSecret,omitempty"`
+
 	// Set Check Rate for the monitor
 	// +optional
 	CheckRate int `json:"checkRate,omitempty"`
@@ -299,7 +303,6 @@ type PingdomConfig struct {
 
 // PingdomTransactionConfig defines the configuration for Pingdom Transaction Monitor Provider
 type PingdomTransactionConfig struct {
-
 	// Check status: active or inactive
 	// +optional
 	Paused bool `json:"paused,omitempty"`

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -232,7 +232,6 @@ type StatusCakeConfig struct {
 
 // PingdomConfig defines the configuration for Pingdom Monitor Provider
 type PingdomConfig struct {
-
 	// The pingdom check interval in minutes
 	// +optional
 	Resolution int `json:"resolution,omitempty"`
@@ -304,6 +303,7 @@ type PingdomConfig struct {
 
 // PingdomTransactionConfig defines the configuration for Pingdom Transaction Monitor Provider
 type PingdomTransactionConfig struct {
+
 	// Check status: active or inactive
 	// +optional
 	Paused bool `json:"paused,omitempty"`

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -232,6 +232,7 @@ type StatusCakeConfig struct {
 
 // PingdomConfig defines the configuration for Pingdom Monitor Provider
 type PingdomConfig struct {
+
 	// The pingdom check interval in minutes
 	// +optional
 	Resolution int `json:"resolution,omitempty"`

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -163,7 +163,7 @@ type StatusCakeConfig struct {
 	// +optional
 	BasicAuthUser string `json:"basicAuthUser,omitempty"`
 
-	// Basic Auth String
+	// Basic Auth Secret Name
 	// +optional
 	BasicAuthSecret string `json:"basicAuthSecret,omitempty"`
 

--- a/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: endpointmonitors.endpointmonitor.stakater.com
 spec:
   group: endpointmonitor.stakater.com
@@ -255,6 +255,9 @@ spec:
               statusCakeConfig:
                 description: Configuration for StatusCake Monitor Provider
                 properties:
+                  basicAuthSecret:
+                    description: Basic Auth Secret Name
+                    type: string
                   basicAuthUser:
                     description: Basic Auth User
                     type: string

--- a/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-  creationTimestamp: null
     controller-gen.kubebuilder.io/version: v0.14.0
+  creationTimestamp: null
   name: endpointmonitors.endpointmonitor.stakater.com
 spec:
   group: endpointmonitor.stakater.com

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: endpointmonitors.endpointmonitor.stakater.com
 spec:
   group: endpointmonitor.stakater.com
@@ -21,14 +20,19 @@ spec:
         description: EndpointMonitor is the Schema for the endpointmonitors API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -65,9 +69,9 @@ spec:
                 properties:
                   alertSensitivity:
                     default: none
-                    description: The alertSensitivity value defaults to none if there
-                      are no alerts or can be set to low, medium, or high to correspond
-                      to the check alert levels.
+                    description: |-
+                      The alertSensitivity value defaults to none if there are no alerts or can be set to low, medium,
+                      or high to correspond to the check alert levels.
                     enum:
                     - none
                     - low
@@ -80,11 +84,10 @@ spec:
                     format: int64
                     type: integer
                   probes:
-                    description: Probes are the monitoring agents responsible for
-                      simulating user interactions with your web applications or services.
-                      These agents periodically send requests to predefined URLs and
-                      record the responses, checking for expected outcomes and measuring
-                      performance.
+                    description: |-
+                      Probes are the monitoring agents responsible for simulating user interactions with your web applications
+                      or services. These agents periodically send requests to predefined URLs and record the responses,
+                      checking for expected outcomes and measuring performance.
                     items:
                       type: string
                     type: array
@@ -114,18 +117,17 @@ spec:
                     description: Set to "true" to pause checks
                     type: boolean
                   postDataEnvVar:
-                    description: Data that should be posted to the web page, for example
-                      submission data for a sign-up or login form. The data needs
-                      to be formatted in the same way as a web browser would send
-                      it to the web server. Because post data contains sensitive secret
-                      this field is only a reference to an environment variable.
+                    description: |-
+                      Data that should be posted to the web page, for example submission data for a sign-up or login form.
+                      The data needs to be formatted in the same way as a web browser would send it to the web server.
+                      Because post data contains sensitive secret this field is only a reference to an environment variable.
                     type: string
                   requestHeaders:
                     description: Custom request headers
                     type: string
                   requestHeadersEnvVar:
-                    description: Custom request headers that should be read from an
-                      environment variable as it possibly contains sensitive data.
+                    description: |-
+                      Custom request headers that should be read from an environment variable as it possibly contains sensitive data.
                       An example would be an API token.
                     type: string
                   resolution:
@@ -139,11 +141,10 @@ spec:
                       HTML code of the page
                     type: string
                   sslDownDaysBefore:
-                    description: Consider down prior to certificate expiring Select
-                      the number of days prior to your certificate expiry date that
-                      you want to consider the check down. At this day your check
-                      will be considered down and if applicable a down alert will
-                      be sent.
+                    description: |-
+                      Consider down prior to certificate expiring
+                      Select the number of days prior to your certificate expiry date that you want to consider the check down.
+                      At this day your check will be considered down and if applicable a down alert will be sent.
                     type: integer
                   tags:
                     description: Comma separated set of tags to apply to check (e.g.
@@ -153,11 +154,11 @@ spec:
                     description: '`-` separated team id''s (e.g. "1234567_8_9-9876543_2_1")'
                     type: string
                   verifyCertificate:
-                    description: Monitor SSL/TLS certificate Monitor the validity
-                      of your SSL/TLS certificate. With this enabled Uptime checks
-                      will be considered DOWN when the certificate becomes invalid
-                      or expires. SSL/TLS certificate monitoring is available for
-                      HTTP checks.
+                    description: |-
+                      Monitor SSL/TLS certificate
+                      Monitor the validity of your SSL/TLS certificate. With this enabled Uptime checks will be considered DOWN when
+                      the certificate becomes invalid or expires.
+                      SSL/TLS certificate monitoring is available for HTTP checks.
                     type: boolean
                 type: object
               pingdomTransactionConfig:
@@ -218,18 +219,17 @@ spec:
                         args:
                           additionalProperties:
                             type: string
-                          description: 'contains the html element with assigned value
-                            the key element is always lowercase for example {"url":
-                            "https://www.pingdom.com"} see available values at https://pkg.go.dev/github.com/karlderkaefer/pingdom-golang-client@latest/pkg/pingdom/client/tmschecks#StepArg'
+                          description: |-
+                            contains the html element with assigned value
+                            the key element is always lowercase for example {"url": "https://www.pingdom.com"}
+                            see available values at https://pkg.go.dev/github.com/karlderkaefer/pingdom-golang-client@latest/pkg/pingdom/client/tmschecks#StepArg
                           type: object
                         function:
-                          description: 'contains the function that is executed as
-                            part of the step commands: go_to, click, fill, check,
-                            uncheck, sleep, select_radio, basic_auth, submit, wait_for_element,
-                            wait_for_contains validations: url, exists, not_exists,
-                            contains, not_contains, field_contains, field_not_contains,
-                            is_checked, is_not_checked, radio_selected, dropdown_selected,
-                            dropdown_not_selected see updated list https://docs.pingdom.com/api/#section/TMS-Steps-Vocabulary/Script-transaction-checks'
+                          description: |-
+                            contains the function that is executed as part of the step
+                            commands: go_to, click, fill, check, uncheck, sleep, select_radio, basic_auth, submit, wait_for_element, wait_for_contains
+                            validations: url, exists, not_exists, contains, not_contains, field_contains, field_not_contains, is_checked, is_not_checked, radio_selected, dropdown_selected, dropdown_not_selected
+                            see updated list https://docs.pingdom.com/api/#section/TMS-Steps-Vocabulary/Script-transaction-checks
                           type: string
                       required:
                       - args
@@ -351,9 +351,9 @@ spec:
                       this monitor
                     type: string
                   customHTTPStatuses:
-                    description: 'Defines which http status codes are treated as up
-                      or down For ex: 200:0_401:1_503:1 (to accept 200 as down and
-                      401 and 503 as up)'
+                    description: |-
+                      Defines which http status codes are treated as up or down
+                      For ex: 200:0_401:1_503:1 (to accept 200 as down and 401 and 503 as up)
                     type: string
                   interval:
                     description: The uptimerobot check interval in seconds

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -21,17 +21,15 @@ spec:
         description: EndpointMonitor is the Schema for the endpointmonitors API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the clients
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -68,8 +66,9 @@ spec:
                 properties:
                   alertSensitivity:
                     default: none
-                    description: 'The alertSensitivity value defaults to none if there are no alerts or can be set to low, medium,
-                      or high to correspond to the check alert levels.'
+                    description: 'The alertSensitivity value defaults to none if there
+                      are no alerts or can be set to low, medium, or high to correspond
+                      to the check alert levels.'
                     enum:
                     - none
                     - low
@@ -82,9 +81,11 @@ spec:
                     format: int64
                     type: integer
                   probes:
-                    description: Probes are the monitoring agents responsible for simulating user interactions with your web applications
-                      or services. These agents periodically send requests to predefined URLs and record the responses,
-                      checking for expected outcomes and measuring performance.
+                    description: Probes are the monitoring agents responsible for
+                      simulating user interactions with your web applications or services.
+                      These agents periodically send requests to predefined URLs and
+                      record the responses, checking for expected outcomes and measuring
+                      performance.
                     items:
                       type: string
                     type: array
@@ -114,15 +115,18 @@ spec:
                     description: Set to "true" to pause checks
                     type: boolean
                   postDataEnvVar:
-                    description: Data that should be posted to the web page, for example submission data for a sign-up or login form.
-                      The data needs to be formatted in the same way as a web browser would send it to the web server.
-                      Because post data contains sensitive secret this field is only a reference to an environment variable.
+                    description: Data that should be posted to the web page, for example
+                      submission data for a sign-up or login form. The data needs
+                      to be formatted in the same way as a web browser would send
+                      it to the web server. Because post data contains sensitive secret
+                      this field is only a reference to an environment variable.
                     type: string
                   requestHeaders:
                     description: Custom request headers
                     type: string
                   requestHeadersEnvVar:
-                    description: Custom request headers that should be read from an environment variable as it possibly contains sensitive data.
+                    description: Custom request headers that should be read from an
+                      environment variable as it possibly contains sensitive data.
                       An example would be an API token.
                     type: string
                   resolution:
@@ -136,9 +140,11 @@ spec:
                       HTML code of the page
                     type: string
                   sslDownDaysBefore:
-                    description: Consider down prior to certificate expiring
-                      Select the number of days prior to your certificate expiry date that you want to consider the check down.
-                      At this day your check will be considered down and if applicable a down alert will be sent.
+                    description: Consider down prior to certificate expiring Select
+                      the number of days prior to your certificate expiry date that
+                      you want to consider the check down. At this day your check
+                      will be considered down and if applicable a down alert will
+                      be sent.
                     type: integer
                   tags:
                     description: Comma separated set of tags to apply to check (e.g.
@@ -148,10 +154,11 @@ spec:
                     description: '`-` separated team id''s (e.g. "1234567_8_9-9876543_2_1")'
                     type: string
                   verifyCertificate:
-                    description: Monitor SSL/TLS certificate
-                      Monitor the validity of your SSL/TLS certificate. With this enabled Uptime checks will be considered DOWN when
-                      the certificate becomes invalid or expires.
-                      SSL/TLS certificate monitoring is available for HTTP checks.
+                    description: Monitor SSL/TLS certificate Monitor the validity
+                      of your SSL/TLS certificate. With this enabled Uptime checks
+                      will be considered DOWN when the certificate becomes invalid
+                      or expires. SSL/TLS certificate monitoring is available for
+                      HTTP checks.
                     type: boolean
                 type: object
               pingdomTransactionConfig:
@@ -213,14 +220,17 @@ spec:
                           additionalProperties:
                             type: string
                           description: 'contains the html element with assigned value
-                            the key element is always lowercase for example {"url": "https://www.pingdom.com"}
-                            see available values at https://pkg.go.dev/github.com/karlderkaefer/pingdom-golang-client@latest/pkg/pingdom/client/tmschecks#StepArg'
+                            the key element is always lowercase for example {"url":
+                            "https://www.pingdom.com"} see available values at https://pkg.go.dev/github.com/karlderkaefer/pingdom-golang-client@latest/pkg/pingdom/client/tmschecks#StepArg'
                           type: object
                         function:
-                          description: 'contains the function that is executed as part of the step
-                            commands: go_to, click, fill, check, uncheck, sleep, select_radio, basic_auth, submit, wait_for_element, wait_for_contains
-                            validations: url, exists, not_exists, contains, not_contains, field_contains, field_not_contains, is_checked, is_not_checked, radio_selected, dropdown_selected, dropdown_not_selected
-                            see updated list https://docs.pingdom.com/api/#section/TMS-Steps-Vocabulary/Script-transaction-checks'
+                          description: 'contains the function that is executed as
+                            part of the step commands: go_to, click, fill, check,
+                            uncheck, sleep, select_radio, basic_auth, submit, wait_for_element,
+                            wait_for_contains validations: url, exists, not_exists,
+                            contains, not_contains, field_contains, field_not_contains,
+                            is_checked, is_not_checked, radio_selected, dropdown_selected,
+                            dropdown_not_selected see updated list https://docs.pingdom.com/api/#section/TMS-Steps-Vocabulary/Script-transaction-checks'
                           type: string
                       required:
                       - args
@@ -345,8 +355,9 @@ spec:
                       this monitor
                     type: string
                   customHTTPStatuses:
-                    description: 'Defines which http status codes are treated as up or down
-                      For ex: 200:0_401:1_503:1 (to accept 200 as down and 401 and 503 as up)'
+                    description: 'Defines which http status codes are treated as up
+                      or down For ex: 200:0_401:1_503:1 (to accept 200 as down
+                      and 401 and 503 as up)'
                     type: string
                   interval:
                     description: The uptimerobot check interval in seconds

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  creationTimestamp: null
   name: endpointmonitors.endpointmonitor.stakater.com
 spec:
   group: endpointmonitor.stakater.com
@@ -20,19 +21,17 @@ spec:
         description: EndpointMonitor is the Schema for the endpointmonitors API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
+            description: 'APIVersion defines the versioned schema of this representation of an object.
               Servers should convert recognized schemas to the latest internal value, and
               may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
+            description: 'Kind is a string value representing the REST resource this object represents.
               Servers may infer this from the endpoint the client submits requests to.
               Cannot be updated.
               In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -69,9 +68,8 @@ spec:
                 properties:
                   alertSensitivity:
                     default: none
-                    description: |-
-                      The alertSensitivity value defaults to none if there are no alerts or can be set to low, medium,
-                      or high to correspond to the check alert levels.
+                    description: 'The alertSensitivity value defaults to none if there are no alerts or can be set to low, medium,
+                      or high to correspond to the check alert levels.'
                     enum:
                     - none
                     - low
@@ -84,8 +82,7 @@ spec:
                     format: int64
                     type: integer
                   probes:
-                    description: |-
-                      Probes are the monitoring agents responsible for simulating user interactions with your web applications
+                    description: Probes are the monitoring agents responsible for simulating user interactions with your web applications
                       or services. These agents periodically send requests to predefined URLs and record the responses,
                       checking for expected outcomes and measuring performance.
                     items:
@@ -117,8 +114,7 @@ spec:
                     description: Set to "true" to pause checks
                     type: boolean
                   postDataEnvVar:
-                    description: |-
-                      Data that should be posted to the web page, for example submission data for a sign-up or login form.
+                    description: Data that should be posted to the web page, for example submission data for a sign-up or login form.
                       The data needs to be formatted in the same way as a web browser would send it to the web server.
                       Because post data contains sensitive secret this field is only a reference to an environment variable.
                     type: string
@@ -126,8 +122,7 @@ spec:
                     description: Custom request headers
                     type: string
                   requestHeadersEnvVar:
-                    description: |-
-                      Custom request headers that should be read from an environment variable as it possibly contains sensitive data.
+                    description: Custom request headers that should be read from an environment variable as it possibly contains sensitive data.
                       An example would be an API token.
                     type: string
                   resolution:
@@ -141,8 +136,7 @@ spec:
                       HTML code of the page
                     type: string
                   sslDownDaysBefore:
-                    description: |-
-                      Consider down prior to certificate expiring
+                    description: Consider down prior to certificate expiring
                       Select the number of days prior to your certificate expiry date that you want to consider the check down.
                       At this day your check will be considered down and if applicable a down alert will be sent.
                     type: integer
@@ -154,8 +148,7 @@ spec:
                     description: '`-` separated team id''s (e.g. "1234567_8_9-9876543_2_1")'
                     type: string
                   verifyCertificate:
-                    description: |-
-                      Monitor SSL/TLS certificate
+                    description: Monitor SSL/TLS certificate
                       Monitor the validity of your SSL/TLS certificate. With this enabled Uptime checks will be considered DOWN when
                       the certificate becomes invalid or expires.
                       SSL/TLS certificate monitoring is available for HTTP checks.
@@ -219,17 +212,15 @@ spec:
                         args:
                           additionalProperties:
                             type: string
-                          description: |-
-                            contains the html element with assigned value
+                          description: 'contains the html element with assigned value
                             the key element is always lowercase for example {"url": "https://www.pingdom.com"}
-                            see available values at https://pkg.go.dev/github.com/karlderkaefer/pingdom-golang-client@latest/pkg/pingdom/client/tmschecks#StepArg
+                            see available values at https://pkg.go.dev/github.com/karlderkaefer/pingdom-golang-client@latest/pkg/pingdom/client/tmschecks#StepArg'
                           type: object
                         function:
-                          description: |-
-                            contains the function that is executed as part of the step
+                          description: 'contains the function that is executed as part of the step
                             commands: go_to, click, fill, check, uncheck, sleep, select_radio, basic_auth, submit, wait_for_element, wait_for_contains
                             validations: url, exists, not_exists, contains, not_contains, field_contains, field_not_contains, is_checked, is_not_checked, radio_selected, dropdown_selected, dropdown_not_selected
-                            see updated list https://docs.pingdom.com/api/#section/TMS-Steps-Vocabulary/Script-transaction-checks
+                            see updated list https://docs.pingdom.com/api/#section/TMS-Steps-Vocabulary/Script-transaction-checks'
                           type: string
                       required:
                       - args
@@ -354,9 +345,8 @@ spec:
                       this monitor
                     type: string
                   customHTTPStatuses:
-                    description: |-
-                      Defines which http status codes are treated as up or down
-                      For ex: 200:0_401:1_503:1 (to accept 200 as down and 401 and 503 as up)
+                    description: 'Defines which http status codes are treated as up or down
+                      For ex: 200:0_401:1_503:1 (to accept 200 as down and 401 and 503 as up)'
                     type: string
                   interval:
                     description: The uptimerobot check interval in seconds

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -255,6 +255,9 @@ spec:
               statusCakeConfig:
                 description: Configuration for StatusCake Monitor Provider
                 properties:
+                  basicAuthSecret:
+                    description: Basic Auth String
+                    type: string
                   basicAuthUser:
                     description: Basic Auth User
                     type: string

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -23,12 +23,11 @@ spec:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the clients
+              object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
@@ -66,9 +65,9 @@ spec:
                 properties:
                   alertSensitivity:
                     default: none
-                    description: 'The alertSensitivity value defaults to none if there
+                    description: The alertSensitivity value defaults to none if there
                       are no alerts or can be set to low, medium, or high to correspond
-                      to the check alert levels.'
+                      to the check alert levels.
                     enum:
                     - none
                     - low
@@ -356,8 +355,8 @@ spec:
                     type: string
                   customHTTPStatuses:
                     description: 'Defines which http status codes are treated as up
-                      or down For ex: 200:0_401:1_503:1 (to accept 200 as down
-                      and 401 and 503 as up)'
+                      or down For ex: 200:0_401:1_503:1 (to accept 200 as down and
+                      401 and 503 as up)'
                     type: string
                   interval:
                     description: The uptimerobot check interval in seconds

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -256,7 +256,7 @@ spec:
                 description: Configuration for StatusCake Monitor Provider
                 properties:
                   basicAuthSecret:
-                    description: Basic Auth String
+                    description: Basic Auth Secret Name
                     type: string
                   basicAuthUser:
                     description: Basic Auth User

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -35,9 +35,9 @@ Statuscake supports checks completing basic auth requirements. In `EndpointMonit
 
 For example; setting the field like `basic-auth-user: 'my-service-username'` will set the username field to the value `my-service-username` and will retrieve the password via `os.Getenv('my-service-username')` and set this appropriately.
 
-In addition to the previous method, you can use the `basicAuthSecret` field to define a secret that should be read by the monitor which contains the basic-auth data. This should be a generic kubernetes secret with the secret containing only `username: password`. This setting expects the `basicAuthUser` field to be filled in, so that we know what key to read from the secret. Furthermore, the secret must be present in the same namespace as the monitor. This ensures that we can keep the permissions of the monitor to be as small as possible.
+In addition to the previous method, you can use the `basicAuthSecret` field to define a secret that should be read by the monitor which contains the basic-auth data. This secret should only contain the keys `username` and `password`. It expects the values for those keys to be strings. NOT base64 encoded strings. Furthermore, the secret must be present in the same namespace as the IngressMonitorController operator. This ensures that we can keep the permissions of the operator to be as small as possible.
 
-So for example, if you have a generic secret called `my-deployment-secret` containing the data `user: MyPassword1!` you should set `basicAuthUser: user` and `BasicAuthSecret: my-deployment-secret`. This will ensure that the monitor can read the basic-auth data correctly.
+So for example, if you have a secret called `my-deployment-secret` it should contain the data `username: my-user` and `password: MyPassword1!` and you should set to `basicAuthSecret: my-deployment-secret`. This will ensure that the monitor can read the basic-auth data correctly.
 
 ## Example:
 

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -16,15 +16,16 @@ Currently additional Statuscake configurations can be added through these fields
 |:--------------------------------------------------------:|:------------------------------------------------:|
 | CheckRate               | Set Check Rate for the monitor (default: 300)    |
 | TestType                | Set Test type - HTTP, TCP, PING (default: HTTP)  |
-| Paused                   | Pause the service                                |
+| Paused                  | Pause the service                                |
 | PingURL                 | Webhook for alerts                               |
 | FollowRedirect          | Enable ingress redirects                         |
-| Port                     | TCP Port                                         |
+| Port                    | TCP Port                                         |
 | TriggerRate             | Minutes to wait before sending an alert          |
 | ContactGroup            | Contact Group to be alerted.                     |
 | TestTags                | Comma separated list of tags                     |
 | FindString              | String to look for within the response           |
-| BasicAuthUser          | Required for [basic-authenticationchecks](#basic-auth-checks)  |
+| BasicAuthUser           | Required for [basic-authenticationchecks](#basic-auth-checks)  |
+| BasicAuthSecret         | Allows for an alternate method of adding basic-auth to checks |
 | Regions                 | Regions to execute the check from                |
 
 
@@ -33,6 +34,10 @@ Currently additional Statuscake configurations can be added through these fields
 Statuscake supports checks completing basic auth requirements. In `EndpointMonitor` the field `basicAuthUser` can be used to trigger the Ingress Monitor attempting to configure this setting. The value of the field should be the *username* to be configured. The Ingress Monitor Controller will then attempt to access an OS env variable of the same name which will return the *password* that should be used. The env variable can be mounted within the Ingress Monitor Controller container via a secret.
 
 For example; setting the field like `basic-auth-user: 'my-service-username'` will set the username field to the value `my-service-username` and will retrieve the password via `os.Getenv('my-service-username')` and set this appropriately.
+
+In addition to the previous method, you can use the `basicAuthSecret` field to define a secret that should be read by the monitor which contains the basic-auth data. This should be a generic kubernetes secret with the secret containing only `username: password`. This setting expects the `basicAuthUser` field to be filled in, so that we know what key to read from the secret. Furthermore, the secret must be present in the same namespace as the monitor. This ensures that we can keep the permissions of the monitor to be as small as possible.
+
+So for example, if you have a generic secret called `my-deployment-secret` containing the data `user: MyPassword1!` you should set `basicAuthUser: user` and `BasicAuthSecret: my-deployment-secret`. This will ensure that the monitor can read the basic-auth data correctly.
 
 ## Example:
 

--- a/examples/endpointMonitor/statuscake-config.yaml
+++ b/examples/endpointMonitor/statuscake-config.yaml
@@ -7,6 +7,7 @@ spec:
   statusCakeConfig:
     port: 123
     basicAuthUser: my-service-username
+    basicAuthSecret: my-basicauth-secret
     checkRate: 300
     realBrowser: true
     testTags: 'abc,def'

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -12,10 +12,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -30,14 +26,14 @@ func getConfig() (*rest.Config, error) {
 	if kubeconfigPath == "" {
 		kubeconfigPath = os.Getenv("HOME") + "/.kube/config"
 	}
-	// If file exists so use that config settings
+	//If file exists so use that config settings
 	if _, err := os.Stat(kubeconfigPath); err == nil {
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		// Use Incluster Configuration
+		//Use Incluster Configuration
 		config, err = rest.InClusterConfig()
 		if err != nil {
 			return nil, err
@@ -57,24 +53,6 @@ func GetClient() (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 	return kubernetes.NewForConfig(config)
-}
-
-func CreateSingleClient() (client.Client, error) {
-	config, err := getConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	s := runtime.NewScheme()
-	if err := scheme.AddToScheme(s); err != nil {
-		return nil, err
-	}
-
-	k8sClient, err := client.New(config, client.Options{Scheme: s})
-	if err != nil {
-		return nil, err
-	}
-	return k8sClient, err
 }
 
 // IsRoute returns true if given resource is a route

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -12,6 +12,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -26,14 +30,14 @@ func getConfig() (*rest.Config, error) {
 	if kubeconfigPath == "" {
 		kubeconfigPath = os.Getenv("HOME") + "/.kube/config"
 	}
-	//If file exists so use that config settings
+	// If file exists so use that config settings
 	if _, err := os.Stat(kubeconfigPath); err == nil {
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		//Use Incluster Configuration
+		// Use Incluster Configuration
 		config, err = rest.InClusterConfig()
 		if err != nil {
 			return nil, err
@@ -53,6 +57,24 @@ func GetClient() (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 	return kubernetes.NewForConfig(config)
+}
+
+func CreateSingleClient() (client.Client, error) {
+	config, err := getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		return nil, err
+	}
+
+	k8sClient, err := client.New(config, client.Options{Scheme: s})
+	if err != nil {
+		return nil, err
+	}
+	return k8sClient, err
 }
 
 // IsRoute returns true if given resource is a route

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -100,9 +100,12 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 		}
 	}
 
+	if providerConfig != nil && len(providerConfig.BasicAuthSecret) > 0 {
+		log.Info("The secret name is: %s", providerConfig.BasicAuthSecret)
+	}
+
 	if providerConfig != nil && len(providerConfig.StatusCodes) > 0 {
 		f.Add("status_codes_csv", providerConfig.StatusCodes)
-
 	} else {
 		statusCodes := []string{
 			"204", // No content
@@ -243,7 +246,6 @@ func (service *StatusCakeMonitorService) GetByName(name string) (*models.Monitor
 	}
 	errorString := "GetByName Request failed for name: " + name
 	return nil, errors.New(errorString)
-
 }
 
 // GetByID function will Get a monitor by it's ID
@@ -445,7 +447,6 @@ func (service *StatusCakeMonitorService) Remove(m models.Monitor) {
 	}
 	if resp.StatusCode != http.StatusNoContent {
 		log.Error(nil, fmt.Sprintf("Delete Request failed for Monitor: %s with id: %s", m.Name, m.ID))
-
 	} else {
 		_, err = service.GetByID(m.ID)
 		if strings.Contains(err.Error(), "Request failed") {

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -88,7 +88,7 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 		}
 	}
 
-	if providerConfig != nil && len(providerConfig.BasicAuthUser) > 0 && len(providerConfig.BasicAuthSecret) == 0 {
+	if providerConfig != nil && len(providerConfig.BasicAuthUser) > 0 {
 		// This value is mandatory
 		// Environment variable should define the password
 		// Mounted via a secret; key is the username, value is the password

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -122,6 +122,7 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 
 	if providerConfig != nil && len(providerConfig.StatusCodes) > 0 {
 		f.Add("status_codes_csv", providerConfig.StatusCodes)
+
 	} else {
 		statusCodes := []string{
 			"204", // No content
@@ -262,6 +263,7 @@ func (service *StatusCakeMonitorService) GetByName(name string) (*models.Monitor
 	}
 	errorString := "GetByName Request failed for name: " + name
 	return nil, errors.New(errorString)
+
 }
 
 // GetByID function will Get a monitor by it's ID
@@ -463,6 +465,7 @@ func (service *StatusCakeMonitorService) Remove(m models.Monitor) {
 	}
 	if resp.StatusCode != http.StatusNoContent {
 		log.Error(nil, fmt.Sprintf("Delete Request failed for Monitor: %s with id: %s", m.Name, m.ID))
+
 	} else {
 		_, err = service.GetByID(m.ID)
 		if strings.Contains(err.Error(), "Request failed") {

--- a/pkg/secret/secrets.go
+++ b/pkg/secret/secrets.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -22,4 +24,25 @@ func LoadSecretData(apiReader client.Reader, secretName, namespace, dataKey stri
 		return "", fmt.Errorf("secret %s did not contain key %s", secretName, dataKey)
 	}
 	return string(retStr), nil
+}
+
+func ReadBasicAuthSecret(apiReader clientv1.SecretInterface, secretName string) (string, string, error) {
+	secret, err := apiReader.Get(context.TODO(), secretName, metav1.GetOptions{})
+	var username, password string
+	if err != nil {
+		return "", "", err
+	}
+
+	for key, value := range secret.Data {
+		switch key {
+		case "username":
+			username = string(value)
+		case "password":
+			password = string(value)
+		default:
+			return "", "", fmt.Errorf("secret %s contained unkown key %s", secretName, key)
+		}
+	}
+
+	return username, password, err
 }

--- a/pkg/secret/secrets.go
+++ b/pkg/secret/secrets.go
@@ -28,7 +28,7 @@ func LoadSecretData(apiReader client.Reader, secretName, namespace, dataKey stri
 
 func ReadBasicAuthSecret(apiReader clientv1.SecretInterface, secretName string) (string, string, error) {
 	secret, err := apiReader.Get(context.TODO(), secretName, metav1.GetOptions{})
-	var username, password string
+	username, password := "", ""
 	if err != nil {
 		return "", "", err
 	}
@@ -42,6 +42,14 @@ func ReadBasicAuthSecret(apiReader clientv1.SecretInterface, secretName string) 
 		default:
 			return "", "", fmt.Errorf("secret %s contained unkown key %s", secretName, key)
 		}
+	}
+
+	if username == "" {
+		return "", "", fmt.Errorf("secret %s does not contain expected key '%s'", secretName, "username")
+	} else if password == "" {
+		return "", "", fmt.Errorf("secret %s does not contain expected key '%s'", secretName, "password")
+	} else if username == "" && password == "" {
+		return "", "", fmt.Errorf("secret %s does not contain expected keys '%s','%s'", secretName, "username", "password")
 	}
 
 	return username, password, err


### PR DESCRIPTION
Reads basic-auth data from secret. Does that by creating a kubernetes client based on the service account used by the pod and reading secrets in it's own namespace. For more info read the included docs.

To Test:
1. run a local kubernetes cluster and set KUBECONFIG to the correct kubeconfig
2. run `make install` in repo dir
3. run the local docker registry `docker run -d -p 5000:5000 --name registry registry:2`
4. build the image and push it
  - `docker build -t localhost:5000/controller:latest .`
  - `docker push localhost:5000/controller:latest`
5. add the secret `imc-config` and `test-secret` and the endpoint monitor (ask me for the commands)
5. run `make deploy`
6. edit the deployment in `ingressmonitorcontroller-system` to use the image `localhost:5000/controller:latest`
7. kill the pod so it pulls the most recent version