### PR TITLE
Add timeout to statuscake endpointmonitor

### DIFF
--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -236,6 +236,12 @@ type StatusCakeConfig struct {
 	// UserAgent is used to set a user agent string.
 	// +optional
 	UserAgent string `json:"userAgent,omitempty"`
+
+	// Timeout is used to set a user agent string.
+	// +kubebuilder:validation:Maximum=75
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Timeout int `json:"timeout,omitempty"`
 }
 
 // PingdomConfig defines the configuration for Pingdom Monitor Provider

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -239,7 +239,7 @@ type StatusCakeConfig struct {
 
 	// Timeout is used to set a user agent string.
 	// +kubebuilder:validation:Maximum=75
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	// +optional
 	Timeout int `json:"timeout,omitempty"`
 }

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -311,6 +311,11 @@ spec:
                   testType:
                     description: Set Test type - HTTP, TCP, PING
                     type: string
+                  timeout:
+                    description: Timeout is used to set a user agent string.
+                    maximum: 75
+                    minimum: 0
+                    type: integer
                   triggerRate:
                     description: Minutes to wait before sending an alert
                     type: integer

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -314,7 +314,7 @@ spec:
                   timeout:
                     description: Timeout is used to set a user agent string.
                     maximum: 75
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   triggerRate:
                     description: Minutes to wait before sending an alert

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -12,23 +12,24 @@ The following properties need to be configured for Statuscake, in addition to th
 
 Currently additional Statuscake configurations can be added through these fields:
 
-|                        Fields                        |                    Description                   |
-|:--------------------------------------------------------:|:------------------------------------------------:|
-| CheckRate               | Set Check Rate for the monitor (default: 300)    |
-| TestType                | Set Test type - HTTP, TCP, PING (default: HTTP)  |
-| Paused                  | Pause the service                                |
-| PingURL                 | Webhook for alerts                               |
-| FollowRedirect          | Enable ingress redirects                         |
-| Port                    | TCP Port                                         |
-| TriggerRate             | Minutes to wait before sending an alert          |
-| ContactGroup            | Contact Group to be alerted.                     |
-| TestTags                | Comma separated list of tags                     |
-| FindString              | String to look for within the response           |
-| BasicAuthUser           | Required for [basic-authenticationchecks](#basic-auth-checks)  |
-| BasicAuthSecret         | Allows for an alternate method of adding basic-auth to checks |
-| Regions                 | Regions to execute the check from                |
-| RawPostData             | Add data to change the request to a POST         |
-| UserAgent               | Add a user agent string to the request           |
+| Fields          | Description                                                   |
+|:---------------:|:-------------------------------------------------------------:|
+| CheckRate       | Set Check Rate for the monitor (default: 300)                 |
+| TestType        | Set Test type - HTTP, TCP, PING (default: HTTP)               |
+| Paused          | Pause the service                                             |
+| PingURL         | Webhook for alerts                                            |
+| FollowRedirect  | Enable ingress redirects                                      |
+| Port            | TCP Port                                                      |
+| TriggerRate     | Minutes to wait before sending an alert                       |
+| ContactGroup    | Contact Group to be alerted.                                  |
+| TestTags        | Comma separated list of tags                                  |
+| FindString      | String to look for within the response                        |
+| BasicAuthUser   | Required for [basic-authenticationchecks](#basic-auth-checks) |
+| BasicAuthSecret | Allows for an alternate method of adding basic-auth to checks |
+| Regions         | Regions to execute the check from                             |
+| RawPostData     | Add data to change the request to a POST                      |
+| UserAgent       | Add a user agent string to the request                        |
+| Timeout         | Timeout for the check                                         |
 
 
 ### Basic Auth checks

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -29,7 +29,7 @@ Currently additional Statuscake configurations can be added through these fields
 | Regions         | Regions to execute the check from                               |
 | RawPostData     | Add data to change the request to a POST                        |
 | UserAgent       | Add a user agent string to the request                          |
-| Timeout         | Timeout for the check in seconds (minimum of 0 and maximum of 75|
+| Timeout         | Timeout for the check in seconds (minimum of 1 and maximum of 75|
 
 
 ### Basic Auth checks

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -12,24 +12,24 @@ The following properties need to be configured for Statuscake, in addition to th
 
 Currently additional Statuscake configurations can be added through these fields:
 
-| Fields          | Description                                                   |
-|:---------------:|:-------------------------------------------------------------:|
-| CheckRate       | Set Check Rate for the monitor (default: 300)                 |
-| TestType        | Set Test type - HTTP, TCP, PING (default: HTTP)               |
-| Paused          | Pause the service                                             |
-| PingURL         | Webhook for alerts                                            |
-| FollowRedirect  | Enable ingress redirects                                      |
-| Port            | TCP Port                                                      |
-| TriggerRate     | Minutes to wait before sending an alert                       |
-| ContactGroup    | Contact Group to be alerted.                                  |
-| TestTags        | Comma separated list of tags                                  |
-| FindString      | String to look for within the response                        |
-| BasicAuthUser   | Required for [basic-authenticationchecks](#basic-auth-checks) |
-| BasicAuthSecret | Allows for an alternate method of adding basic-auth to checks |
-| Regions         | Regions to execute the check from                             |
-| RawPostData     | Add data to change the request to a POST                      |
-| UserAgent       | Add a user agent string to the request                        |
-| Timeout         | Timeout for the check                                         |
+| Fields          | Description                                                     |
+|:---------------:|:---------------------------------------------------------------:|
+| CheckRate       | Set Check Rate for the monitor (default: 300)                   |
+| TestType        | Set Test type - HTTP, TCP, PING (default: HTTP)                 |
+| Paused          | Pause the service                                               |
+| PingURL         | Webhook for alerts                                              |
+| FollowRedirect  | Enable ingress redirects                                        |
+| Port            | TCP Port                                                        |
+| TriggerRate     | Minutes to wait before sending an alert                         |
+| ContactGroup    | Contact Group to be alerted.                                    |
+| TestTags        | Comma separated list of tags                                    |
+| FindString      | String to look for within the response                          |
+| BasicAuthUser   | Required for [basic-authenticationchecks](#basic-auth-checks)   |
+| BasicAuthSecret | Allows for an alternate method of adding basic-auth to checks   |
+| Regions         | Regions to execute the check from                               |
+| RawPostData     | Add data to change the request to a POST                        |
+| UserAgent       | Add a user agent string to the request                          |
+| Timeout         | Timeout for the check in seconds (minimum of 0 and maximum of 75|
 
 
 ### Basic Auth checks

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -240,6 +240,9 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 	if providerConfig != nil && len(providerConfig.UserAgent) > 0 {
 		f.Add("user_agent", providerConfig.UserAgent)
 	}
+	if providerConfig != nil && providerConfig.Timeout > 0 {
+		f.Add("timeout", strconv.Itoa(providerConfig.Timeout))
+	}
 	return f
 }
 

--- a/pkg/monitors/statuscake/statuscake-monitor_test.go
+++ b/pkg/monitors/statuscake/statuscake-monitor_test.go
@@ -114,6 +114,7 @@ func TestBuildUpsertForm(t *testing.T) {
 		Confirmation:   2,
 		EnableSSLAlert: true,
 		FindString:     "",
+                Timeout:        30,
 
 		// changed to string array type on statuscake api
 		// TODO: release new apiVersion to cater new type in apiVersion struct
@@ -143,4 +144,5 @@ func TestBuildUpsertForm(t *testing.T) {
 	assert.Equal(t, "test,testrun,uptime", convertUrlValuesToString(vals, "tags[]"))
 	assert.Equal(t, "TCP", vals.Get("test_type"))
 	assert.Equal(t, "1", vals.Get("trigger_rate"))
+	assert.Equal(t, "30", vals.Get("timeout"))
 }

--- a/pkg/monitors/statuscake/statuscake-monitor_test.go
+++ b/pkg/monitors/statuscake/statuscake-monitor_test.go
@@ -114,7 +114,7 @@ func TestBuildUpsertForm(t *testing.T) {
 		Confirmation:   2,
 		EnableSSLAlert: true,
 		FindString:     "",
-                Timeout:        30,
+        Timeout:        30,
 
 		// changed to string array type on statuscake api
 		// TODO: release new apiVersion to cater new type in apiVersion struct


### PR DESCRIPTION
StatusCake allows the user to set a timeout. I added it to the configuration to enable users of IngressMonitorController to add/change it as well.